### PR TITLE
Develop/1.0.38 38_ドキュメントの必要性と作り方 課題提出

### DIFF
--- a/src/main/java/studentManagementSystem/testDemo/Controller/StudentController.java
+++ b/src/main/java/studentManagementSystem/testDemo/Controller/StudentController.java
@@ -25,6 +25,9 @@ import studentManagementSystem.testDemo.exception.ErrorMessages;
 import studentManagementSystem.testDemo.exception.TestException;
 import studentManagementSystem.testDemo.service.StudentService;
 
+// 38_ドキュメントの必要性と作り方 課題
+// ControllerにおけるOpenAPIをすべて実装する
+
 /**
  * 受講生の検索や登録、更新を行うREST APIとして受け付けるControllerです
  */

--- a/src/main/java/studentManagementSystem/testDemo/Controller/StudentController.java
+++ b/src/main/java/studentManagementSystem/testDemo/Controller/StudentController.java
@@ -90,7 +90,7 @@ public class StudentController {
       description = "受講生ID",
       example = "1"
   )
-  @GetMapping("/student/{studentId}")
+  @GetMapping("/students/{studentId}")
   public StudentDetail getStudent(
       @PathVariable @NotBlank @Pattern(regexp = "^\\d+$") String studentId) {
     return service.searchStudent(studentId);

--- a/src/main/java/studentManagementSystem/testDemo/Controller/StudentController.java
+++ b/src/main/java/studentManagementSystem/testDemo/Controller/StudentController.java
@@ -1,6 +1,13 @@
 package studentManagementSystem.testDemo.Controller;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -12,6 +19,7 @@ import org.springframework.ui.Model;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,10 +35,23 @@ import studentManagementSystem.testDemo.service.StudentService;
 
 // 38_ドキュメントの必要性と作り方 課題
 // ControllerにおけるOpenAPIをすべて実装する
+// https://qiita.com/Omi354/items/e52401971354cf2b4317
+// https://qiita.com/crml1206/items/e47ec484af750d301953
+// https://staff.persol-xtech.co.jp/hatalabo/it_engineer/527.html
 
 /**
  * 受講生の検索や登録、更新を行うREST APIとして受け付けるControllerです
  */
+@OpenAPIDefinition(info = @Info(
+    title = "受講生とコース情報の登録、検索、更新、論理削除の処理",
+    description = "受講生と受講生コースの情報を登録、検索、更新、論理削除を行うControllerです。"
+))
+@ApiResponses({
+    @ApiResponse(responseCode = "200", description = "成功"),
+    @ApiResponse(responseCode = "400", description = "リクエストエラー（バリデーションなど）"),
+    @ApiResponse(responseCode = "404", description = "データが見つかりません"),
+    @ApiResponse(responseCode = "500", description = "サーバーエラー")
+})
 @Validated
 @RestController
 public class StudentController {
@@ -63,19 +84,16 @@ public class StudentController {
    * @param studentId 受講生ID
    * @return 受講生情報
    */
+  @Operation(summary = "単一検索", description = "受講生のIDに基づく情報を取得します")
+  @Parameter(
+      name = "studentId",
+      description = "受講生ID",
+      example = "1"
+  )
   @GetMapping("/student/{studentId}")
   public StudentDetail getStudent(
       @PathVariable @NotBlank @Pattern(regexp = "^\\d+$") String studentId) {
     return service.searchStudent(studentId);
-  }
-
-
-  @GetMapping("/newStudent")
-  public String newStudent(Model model) {
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudentCourseList(Arrays.asList(new StudentCourse()));
-    model.addAttribute("studentDetail", studentDetail);
-    return "registerStudent";
   }
 
   /**
@@ -97,6 +115,7 @@ public class StudentController {
    * @param studentDetail
    * @return
    */
+  @Operation(summary = "受講生更新", description = "受講生詳細の更新をします。論理削除も行います。")
   @PutMapping("/updateStudent")
   public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
     service.updateStudent(studentDetail);
@@ -104,7 +123,7 @@ public class StudentController {
   }
 
 
-  // 例外処理用のメソッド
+  @Operation(summary = "例外処理", description = "例外処理を行います。")
   @GetMapping("/exceptionStudentList")
   public List<StudentDetail> handleTestException() throws TestException {
     throw new TestException("TestException:" + ErrorMessages.TestException);

--- a/src/main/java/studentManagementSystem/testDemo/TestDemoApplication.java
+++ b/src/main/java/studentManagementSystem/testDemo/TestDemoApplication.java
@@ -1,12 +1,15 @@
 package studentManagementSystem.testDemo;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-
-@OpenAPIDefinition
+@OpenAPIDefinition(info = @Info(
+		title = "受講生管理システム",
+		description = "受講生情報と受講生のコース情報を管理するシステムです。受講生と受講生コースの情報を登録、読み取り、更新、論理削除ができます。"
+))
 @SpringBootApplication
 @MapperScan("studentManagementSystem.testDemo")
 

--- a/src/main/java/studentManagementSystem/testDemo/data/Student.java
+++ b/src/main/java/studentManagementSystem/testDemo/data/Student.java
@@ -12,18 +12,36 @@ import lombok.Setter;
 @Setter
 
 public class Student {
-
-  @Pattern(regexp = "^\\d+$")
+  @Schema(description = "受講生IDを自動付与", example = "1")
+  @Pattern(regexp = "^\\d+$", message = "整数のみ")
   private String studentId;
+
+  @Schema(description = "氏名", example = "山田太郎")
   private String name;
+
+  @Schema(description = "ふりがな", example = "やまだたろう")
   private String furigana;
+
+  @Schema(description = "ニックネーム", example = "タロ")
   private String nickname;
+
+  @Schema(description = "メールアドレス", example = "taro@example.com")
   @Email
   private String email;
+
+  @Schema(description = "地域", example = "兵庫")
   private String area;
+
+  @Schema(description = "年齢", example = "20")
   private int age;
+
+  @Schema(description = "性別", example = "男性")
   private String gender;
-  private String remark; // 備考欄
+
+  @Schema(description = "備考欄", example = "未経験転職するために、東京へ上京予定。")
+  private String remark;
+
+  @Schema(description = "論理削除", example = "1")
   private boolean isDeleted; // 論理削除
 
 }

--- a/src/main/java/studentManagementSystem/testDemo/data/StudentCourse.java
+++ b/src/main/java/studentManagementSystem/testDemo/data/StudentCourse.java
@@ -12,13 +12,21 @@ import lombok.Setter;
 
 public class StudentCourse {
 
+  @Schema(description = "受講生コースIDを自動付与", example = "1")
   @Pattern(regexp = "^\\d+$")
   private String studentsCoursesId;
 
+  @Schema(description = "受講生ID", example = "1")
   @Pattern(regexp = "^\\d+$")
   private String studentId;
+
+  @Schema(description = "受講コース名", example = "Javaコース")
   private String courseName;
+
+  @Schema(description = "受講開始日", example = "2025-08-01T00:00:00.000+00:00")
   private Timestamp startDate;
+
+  @Schema(description = "受講終了予定日", example = "2026-08-01T00:00:00.000+00:00")
   private Timestamp endDate;
 
 }

--- a/src/main/java/studentManagementSystem/testDemo/domain/StudentDetail.java
+++ b/src/main/java/studentManagementSystem/testDemo/domain/StudentDetail.java
@@ -17,9 +17,11 @@ import studentManagementSystem.testDemo.data.StudentCourse;
 @AllArgsConstructor
 public class StudentDetail {
 
+  @Schema(description = "受講生")
   @Valid
   private Student student;
 
+  @Schema(description = "受講生コース情報")
   @Valid
   private List<StudentCourse> studentCourseList;
 

--- a/src/main/java/studentManagementSystem/testDemo/exception/ErrorMessages.java
+++ b/src/main/java/studentManagementSystem/testDemo/exception/ErrorMessages.java
@@ -2,4 +2,20 @@ package studentManagementSystem.testDemo.exception;
 
 public class ErrorMessages {
   public static final String TestException = "TestException エラーが発生しました";
+
+  // 作ったけど、ここまで不要？
+  public static final String movedPermanently301 = "301 Moved Permanently 指定したリソースは新しいURLに恒久的に移動しました";
+  public static final String found302 = "302 Found 一時的にリソースのURLが変更されています";
+  public static final String seeOther303 = "303 See Other 別のURLでリソースを取得してください";
+  public static final String temporaryRedirect307 = "307 Temporary Redirect 別のURLにリクエストを再送信してください";
+
+  public static final String badRequest400 = "400 Bad Request リクエストの構文ミスです";
+  public static final String unauthorized401 = "401 Unauthorized 認証情報が不足しています";
+  public static final String forbidden403 = "403 Forbidden アクセスが拒否されました";
+  public static final String notFound404 = "404 Not Found リソースが見つかりません";
+  public static final String methodNotAllowed405 = "405 Method Not Allowed 許可されていないHTTPメソッドです";
+
+  public static final String internalServerError500 = "500 Internal Server Error サーバー内部で予期しないエラーが発生しました";
+  public static final String serviceUnavailable503 = "503 Service Unavailable 現在サービスを利用できません（メンテナンス中またはアクセス集中）";
+  public static final String gatewayTimeout504 = "504 Gateway Timeout 上流サーバーとの通信に失敗しました（タイムアウト）";
 }


### PR DESCRIPTION
## 課題内容
ControllerにおけるOpenAPIを実装しました

- classに対して`@OpenAPIDefinition` と `@ApiResponses`を実装
https://github.com/yukidaruma28/student_management/commit/eceded86599cf5740938a76c217cda3bdb553d74#diff-455813d33e29f2b11f215053ffec48b4ddcb8cd01f8d8a8517f017d010afa820R45

- @GetMapping と @PutMappingに対して`@Operation`を実装
https://github.com/yukidaruma28/student_management/commit/eceded86599cf5740938a76c217cda3bdb553d74#diff-455813d33e29f2b11f215053ffec48b4ddcb8cd01f8d8a8517f017d010afa820R87

- @GetMapping("/student/{studentId}") というパラメーターがある場合は、`@Parameter`を実装
https://github.com/yukidaruma28/student_management/commit/eceded86599cf5740938a76c217cda3bdb553d74#diff-455813d33e29f2b11f215053ffec48b4ddcb8cd01f8d8a8517f017d010afa820R87

- student studentCourseに対して`@Schema`を実装
https://github.com/yukidaruma28/student_management/commit/eceded86599cf5740938a76c217cda3bdb553d74#diff-72a9a72052f3a111c86d11aa2d428b329df5fb544a2f74ac8b1d0d19401cfb7dR15


### 参考URL
- [【Spring Boot】OpenAPIを使用したAPI仕様書の作成方法](https://qiita.com/Omi354/items/e52401971354cf2b4317)
- [【Java】SwaggerでAPI仕様を見れるところまでやってみた](https://qiita.com/crml1206/items/e47ec484af750d301953)
- [HTTPステータスコード一覧](https://staff.persol-xtech.co.jp/hatalabo/it_engineer/527.html)

## swagger-ui
表示をすべて出力したため、長いです。申し訳ございません。
![38_ドキュメントの必要性と作り方 課題](https://github.com/user-attachments/assets/bb8009e1-35fb-426a-bc05-3efcad98d730)
